### PR TITLE
Enable path_info while proxying to Tomcat

### DIFF
--- a/etc/nginx/lucee-proxy.conf
+++ b/etc/nginx/lucee-proxy.conf
@@ -11,12 +11,14 @@ proxy_set_header X-Tomcat-DocRoot $document_root;
 proxy_set_header X-ModCFML-SharedKey SHARED-KEY-HERE;
 
 # Enable path_info - http://www.lucee.nl/post.cfm/enable-path-info-on-nginx-with-lucee-and-railo
+set $pathinfo "";
 # if the extension .cfm or .cfc is found, followed by a slash and optional extra
 if ($uri ~ "^(.+?\.cf[mc])(/.*)") {
     # remember the filepath without path_info
     set $script $1;
-    # set the custom path_info header
-    proxy_set_header XAJP-PATH-INFO $2;
+    set $pathinfo $2;
     # rewrite the url to match the filepath wthout path_info
     rewrite ^.+$ $script break;
 }
+# set the custom path_info header
+proxy_set_header XAJP-PATH-INFO $pathinfo;

--- a/etc/nginx/lucee-proxy.conf
+++ b/etc/nginx/lucee-proxy.conf
@@ -9,3 +9,14 @@ proxy_set_header https $cgi_https;
 #add header for mod_cfml to do its work
 proxy_set_header X-Tomcat-DocRoot $document_root;
 proxy_set_header X-ModCFML-SharedKey SHARED-KEY-HERE;
+
+# Enable path_info - http://www.lucee.nl/post.cfm/enable-path-info-on-nginx-with-lucee-and-railo
+# if the extension .cfm or .cfc is found, followed by a slash and optional extra
+if ($uri ~ "^(.+?\.cf[mc])(/.*)") {
+    # remember the filepath without path_info
+    set $script $1;
+    # set the custom path_info header
+    proxy_set_header XAJP-PATH-INFO $2;
+    # rewrite the url to match the filepath wthout path_info
+    rewrite ^.+$ $script break;
+}


### PR DESCRIPTION
Hi Pete,
I hope you want to add this piece of code, as it enables path_info in Lucee/Railo/BD while using nginx-proxy + tomcat.
For reference, see http://www.lucee.nl/post.cfm/enable-path-info-on-nginx-with-lucee-and-railo

Thanks for the install scripts; they were really useful!

Paul