### PR TITLE
Adding scanClassPaths=false to mod_cfml in Tomcat, for improved conte…

### DIFF
--- a/etc/tomcat7/server.xml
+++ b/etc/tomcat7/server.xml
@@ -151,7 +151,8 @@
                 loggingEnabled="false"
                 waitForContext="5"
                 maxContexts="200"
-                timeBetweenContexts="30000"
+                timeBetweenContexts="2000"
+                scanClassPaths="false"
                 sharedKey="SHARED-KEY-HERE"
                 />
 


### PR DESCRIPTION
…xt loading time

2 changes:
1) timeBetweenContexts=2000 (2 seconds), to make sure all contexts can load fast after a Tomcat restart
The old 30 seconds means, only 2 contexts per minute can be created, which can be a pain after a Tomcat restart.
2) added scanClassPaths=false, to improve context loading from +/- 3 seconds to +/- 0.5 seconds.
Scanning classPaths in Tomcat is not necessary for Lucee, it is even discouraged by Michael Offner (Lucee CTO).