### PR TITLE
Added support for the mod_cfml X-Webserver-Context header

### DIFF
--- a/etc/nginx/lucee-proxy.conf
+++ b/etc/nginx/lucee-proxy.conf
@@ -6,9 +6,14 @@ proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X-Forwarded-Proto $scheme;
 #populate the cgi.https variable with on or off based on map condition which must be specified in a http {} block
 proxy_set_header https $cgi_https;
-#add header for mod_cfml to do its work
+
+#add headers for mod_cfml to do its work
 proxy_set_header X-Tomcat-DocRoot $document_root;
 proxy_set_header X-ModCFML-SharedKey SHARED-KEY-HERE;
+if ($lucee_context = false) {
+	set $lucee_context $document_root;
+};
+proxy_set_header X-Webserver-Context $lucee_context;
 
 # Enable path_info - http://www.lucee.nl/post.cfm/enable-path-info-on-nginx-with-lucee-and-railo
 set $pathinfo "";

--- a/etc/nginx/sites-available/default.conf
+++ b/etc/nginx/sites-available/default.conf
@@ -1,5 +1,5 @@
 server {
   listen 80 default_server;
   root /web/default/wwwroot/;
-	index index.html;
+  index index.html;
 }

--- a/etc/nginx/sites-available/example.com.conf
+++ b/etc/nginx/sites-available/example.com.conf
@@ -1,6 +1,26 @@
 server {
   listen 80;
   server_name example.com;
-	root /web/example.com/wwwroot/;
-	include lucee.conf;
+  root /web/example.com/wwwroot/;
+
+  # Lucee specific: add a unique ID for this server block.
+  # By default, the document-root will be used as a unique ID.
+  #
+  # Required to set, if:
+  # A) you are using 'alias' paths in ANY server{...} block, eg.
+  #    location /demo {
+  #	     alias /path/to/alias/folder;
+  #    }
+  # B) you have multiple server blocks with the same 'root' value.
+  #
+  # Make sure you give the $lucee_context variable a unique value.
+  # Otherwise, multiple sites will share the same Lucee context!
+  # Examples:
+  #   set $lucee_context "www.mysite.com";
+  #   set $lucee_context "www.othersite.com";
+  #   set $lucee_context site1;
+  #   set $lucee_context site2;
+  set $lucee_context "example.com";
+
+  include lucee.conf;
 }


### PR DESCRIPTION
Hi Pete,

Like the title says: I Added support for the mod_cfml X-Webserver-Context header.
Please note: it is highly recommended to use this new feature in combination with the not yet available mod_cfml.jar version 1.1.05 (pull request https://github.com/utdream/mod_cfml/pull/12). I assume it will be available tomorrow, August 29. 

I don't particularly like the large comment block in  etc/nginx/sites-available/example.com.conf, but until there is a blog post or anything else, this is the way to go I guess...

Kind regards, Paul