### PR TITLE
fixed an issue where script was prematurely exiting

### DIFF
--- a/scripts/200-lucee.sh
+++ b/scripts/200-lucee.sh
@@ -12,7 +12,7 @@ mkdir /opt/lucee/config/web
 mkdir /opt/lucee/$jar_folder
 curl --location -o /opt/lucee/$jar_folder/lucee.jar $jar_url
 
-if [ -f "/opt/lucee/lucee.zip" ]; then
+if [ -f "/opt/lucee/$jar_folder/lucee.jar" ]; then
   echo "Download Complete"
 else
   echo "Download of Lucee Failed Exiting..."


### PR DESCRIPTION
Just in regards to issue https://github.com/foundeo/ubuntu-nginx-lucee/issues/13

Seems like you had remnants left over from a different branch where you were downloading the express version of lucee which is a zip.  The script was checking for this zip and could not find it so it would exit prematurely.