### PR TITLE
Remove semicolon causing nginx error

### DIFF
--- a/etc/nginx/lucee-proxy.conf
+++ b/etc/nginx/lucee-proxy.conf
@@ -13,7 +13,7 @@ proxy_set_header X-ModCFML-SharedKey SHARED-KEY-HERE;
 # For more info on $lucee_context, see http://www.modcfml.org/index.cfm/install/web-server-components/nginx-all-os/
 if ($lucee_context = false) {
 	set $lucee_context $document_root;
-};
+}
 proxy_set_header X-Webserver-Context $lucee_context;
 
 # Enable path_info - http://www.lucee.nl/post.cfm/enable-path-info-on-nginx-with-lucee-and-railo


### PR DESCRIPTION
Removed the semicolon after the if statement. It was causing an nginx error.