### PR TITLE
Changing to correct links

### DIFF
--- a/scripts/200-lucee.sh
+++ b/scripts/200-lucee.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-jar_url="http://cdn.lucee.org/rest/update/provider/loader/$LUCEE_VERSION"
+jar_url="http://release.lucee.org/rest/update/provider/loader/$LUCEE_VERSION"
 if [[ $LUCEE_LIGHT ]];then
-    jar_url="http://cdn.lucee.org/rest/update/provider/light/$LUCEE_VERSION"
+    jar_url="http://release.lucee.org/rest/update/provider/light/$LUCEE_VERSION"
 fi
 jar_folder="lucee-$LUCEE_VERSION"
 


### PR DESCRIPTION
The links need to be "release." and not "cdn." as the file might not exist in S3 yet, so needs to go via a CFML script to add the file to S3 if it is not there yet.