### PR TITLE
Bugfix for non-working variable checks

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
 #configuration options
-if [[ !$LUCEE_VERSION ]];then
+if [[ "$LUCEE_VERSION" == "" ]];then
     export LUCEE_VERSION="5.3.7.48"
 fi
 
-#if [[ $LUCEE_LIGHT ]];then
+#if [[ "$LUCEE_LIGHT" == "" ]];then
     #export LUCEE_JAR_SHA256=""
 #fi
 
-if [[ !$JVM_MAX_HEAP_SIZE ]];then
+if [[ "$JVM_MAX_HEAP_SIZE" == "" ]];then
     export JVM_MAX_HEAP_SIZE="512m"
 fi
 

--- a/scripts/600-config.sh
+++ b/scripts/600-config.sh
@@ -12,7 +12,7 @@ apt-get update && apt-get install commandbox
 
 box install commandbox-cfconfig
 
-if [[ !$ADMIN_PASSWORD ]]; then
+if [[ "$ADMIN_PASSWORD" == "" ]]; then
     echo "No ADMIN_PASSWORD set, generating a random password and storing it here: /root/lucee-admin-password.txt"
     touch /root/lucee-admin-password.txt
     chown root:root /root/lucee-admin-password.txt


### PR DESCRIPTION
The old `if[[ !$somevar ]]` check does not work at all, tested on OSX and Ubuntu 20.x
This new construct does work as it should.