### PR TITLE
Tomcat9, disable obsolete annoying modcfml setting `timeBetweenContexts`

### DIFF
--- a/etc/tomcat9/server.xml
+++ b/etc/tomcat9/server.xml
@@ -147,7 +147,7 @@
                 loggingEnabled="false"
                 waitForContext="5"
                 maxContexts="200"
-                timeBetweenContexts="2000"
+                timeBetweenContexts="0"
                 scanClassPaths="false"
                 sharedKey="SHARED-KEY-HERE"
                 />


### PR DESCRIPTION
The `timeBetweenContexts` setting of Mod_cfml is obsolete. It was there to work around thread-safety issues. Setting it to 0 means, every visitor will get the web page they want, instead of the text "<h3>Tomcat Mod_CFML error</h3><p>Time Between Contexts has not been fulfilled. Please wait a few moments and try again.</p>"

I left the other 2 Tomcat versions as they are, because they still use the older mod_cfml version.